### PR TITLE
Fix Bug on line 801

### DIFF
--- a/getsploit.py
+++ b/getsploit.py
@@ -798,7 +798,7 @@ def main():
         outputTable.add_rows(tableRows)
         if pythonVersion < 3.0:
             # Just pass non-ascii
-            print(outputTable.draw().decode('ascii', 'ignore'))
+            print(outputTable.draw().encode('ascii', 'ignore'))
         else:
             # Any better solution here?
             print(outputTable.draw().encode('ascii', 'ignore').decode())


### PR DESCRIPTION
Fix the following issue

./getsploit.py kernel 4.0.2
Total found exploits: 6
Web-search URL: https://vulners.com/search?query=bulletinFamily%3Aexploit+AND+kernel+4.0.2
Traceback (most recent call last):
  File "./getsploit.py", line 807, in <module>
    main()
  File "./getsploit.py", line 801, in main
    print(outputTable.draw().decode('ascii', 'ignore'))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 2613-2620: ordinal not in range(128)