### PR TITLE
v0.2.2 packaged up to add to PyPI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.egg-info/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Utility was tested on a *python2.6*, *python2.7*, *python3.6* with SQLite FTS4 s
 
 # How to use
 
+Install: `pip install getsploit`
+
 [![asciicast](https://asciinema.org/a/ObuaXdpxNO0nAo6o821fLCLxZ.png)](https://asciinema.org/a/ObuaXdpxNO0nAo6o821fLCLxZ?autoplay=1)
 
 # Search

--- a/getsploit/__init__.py
+++ b/getsploit/__init__.py
@@ -1,0 +1,13 @@
+__author__ = "Kir Ermakov <isox(at)vulners.com>"
+__copyright__ = "Copyright 2018, Vulners"
+__credits__ = ["Kir Ermakov",
+               "Igor Bulatenko",
+               "Ivan Elkin",
+               "Gerome Fournier <jef(at)foutaise.org>",
+               "JBFC"
+               ]
+__license__ = "LGPL"
+__version__ = "0.2.2"
+__maintainer__ = "Kir Ermakov"
+__email__ = "isox@vulners.com"
+__status__ = "Release"

--- a/getsploit/getsploit.py
+++ b/getsploit/getsploit.py
@@ -1,20 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import division
 
-__author__ = "Kir Ermakov <isox(at)vulners.com>"
-__copyright__ = "Copyright 2017, Vulners"
-__credits__ = ["Kir Ermakov",
-               "Igor Bulatenko",
-               "Ivan Elkin",
-               "Gerome Fournier <jef(at)foutaise.org>",
-               "JBFC"
-               ]
-__license__ = "LGPL"
-__version__ = "0.2.1"
-__maintainer__ = "Kir Ermakov"
-__email__ = "isox@vulners.com"
-__status__ = "Release"
+from __future__ import division
+from __init__ import __version__
 
 try:
     import urllib.request as urllib2

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['getsploit'],
     version=getsploit.__version__,
     description='Command line search and download tool for Vulners Database \
-                 inspired by searchsploit.',
+inspired by searchsploit.',
     long_description=long_description,
     license='LGPLv3',
     url='https://github.com/vulnersCom/getsploit',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import getsploit
+from setuptools import setup
+
+long_description = '''
+getsploit
+=========
+
+Command line search and download tool for Vulners Database inspired by
+searchsploit. It allows you to search online for the exploits across all the
+most popular collections: Exploit-DB, Metasploit, Packetstorm and others. The
+most powerful feature is immediate exploit source download right in your
+working path.
+'''
+
+setup(
+    name='getsploit',
+    packages=['getsploit'],
+    version=getsploit.__version__,
+    description='Command line search and download tool for Vulners Database \
+                 inspired by searchsploit.',
+    long_description=long_description,
+    license='LGPLv3',
+    url='https://github.com/vulnersCom/getsploit',
+    author=getsploit.__author__,
+    author_email=getsploit.__email__,
+    maintainer=getsploit.__maintainer__,
+    entry_points={
+        'console_scripts': [
+            'getsploit = getsploit.getsploit:main',
+        ]
+    },
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Information Technology",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Security",
+    ]
+)


### PR DESCRIPTION
I took the liberty of professionally packaging up this awesome command line tool. With this addition (after the maintainer uploads to PyPI) you could easily install getsploit by doing `pip install getsploit` and use it like a standard command line tool `$ getsploit apache`.

If you merge this PR, just upload by doing `python setup.py sdist upload -r pypi` or similar as long as you have a [PyPI account](https://pypi.python.org/pypi?%3Aaction=register_form). Cheers!